### PR TITLE
Adding `gzip: true` parameter option

### DIFF
--- a/src/support/request.js
+++ b/src/support/request.js
@@ -83,6 +83,7 @@ class Request {
             method,
             headers: this.headers,
             qs: this.queryParameters,
+            gzip: true,
         };
 
         if (this.requestBody.length > 0) {


### PR DESCRIPTION
Fala Thyagão, tranquilo?
velho, tava usando sua lib aqui, mas as responses das minhas requests estavam retornando um `.xml` ao invés de `.json`... aparentemente ele não tava aceitando o `Accept-encoding` (de acordo com essa documentação: https://www.npmjs.com/package/request

daí to abrindo um PR pra vc ver se faz sentido, blz?